### PR TITLE
Add apt key when target distro is Ubuntu.

### DIFF
--- a/tasks/ubuntu_td-agent.yml
+++ b/tasks/ubuntu_td-agent.yml
@@ -5,6 +5,9 @@
   with_items:
     - python-pycurl
 
+- name: Add the Treasuredata apt key
+  apt_key: url=http://packages.treasuredata.com/GPG-KEY-td-agent state=present
+
 - name: Add apt repository
   apt_repository: repo='deb http://packages.treasuredata.com/2/ubuntu/trusty/ trusty contrib' state=present
   when: ansible_distribution_version == '14.04'


### PR DESCRIPTION
This PR adds a couple of lines to the Ubuntu install tasks that ensure the apt key for Treasuredata is present. Without this the following error occurs when performing a `apt-get update`:

```
W: GPG error: http://packages.treasuredata.com trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1093DB45A12E206F
```

The same signing key, which is linked to [here](http://packages.treasuredata.com/) is used to sign all packages.