### PR TITLE
Add simple implementation of plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The variables that can be passed to this role **when the OS is Debian** and a br
     # Architecture of the machine (required, i386 or amd64)
     td_agent_architecture: amd64
 
+You can also pass in a list of plugins to be installed using tg-agent-gem as follows:
+
+    td_agent_plugins:
+    - 'fluent-plugin-secure-forward'
+    - 'fluent-plugin-...'
+
 Detail for [the official intallation page](http://docs.fluentd.org/articles/install-by-deb)
 
 ## Examples

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 td_agent_version: '1.1.18-1'
 # td_agent_architecture: 'i386'
 # td_agent_architecture: 'amd64'
+td_agent_plugins: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,6 @@
 
 - include: debian_td-agent.yml
   when: ansible_distribution == "Debian" and ansible_distribution_version[0] == '6'
+
+- include: plugins.yml
+  when: td_agent_plugins

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,0 +1,13 @@
+---
+- name: Check if plugins are installed
+  command: "td-agent-gem list -i {{item}}"
+  with_items: td_agent_plugins
+  changed_when: False
+  failed_when: False
+  register: td_plugin_status
+
+- name: Install missing plugins
+  command: "td-agent-gem install {{item.item}}"
+  with_items: td_plugin_status.results
+  when: (td_plugin_status.results is defined) and
+        (item.stdout_lines[0] == "false")


### PR DESCRIPTION
If there's any interest, this change adds very simple/naive way to specify fluent plugins that can be installed while provisioning td-agent.